### PR TITLE
Corrected a power of (z-1)

### DIFF
--- a/views/matrixsplit.html
+++ b/views/matrixsplit.html
@@ -581,7 +581,7 @@
 
         <p>\[
           \begin{bmatrix}
-            -(z-1)^3 & 3 \cdot (z-1)^2 \cdot z & -3 \cdot (z-1)^3 \cdot z^2 & z^3 \\
+            -(z-1)^3 & 3 \cdot (z-1)^2 \cdot z & -3 \cdot (z-1) \cdot z^2 & z^3 \\
             0 & (z-1)^2 & -2 \cdot (z-1) \cdot z & z^2 \\
             0 & 0 & -(z-1) & z \\
             0 & 0 & 0 & 1


### PR DESCRIPTION
One of the Bernstein polynomials was written as (in short) a^3 + 3 a^2 b + 3 a^3 b^2 + a^3, instead of a^3 + 3 a^2 b + 3 a b^2 + a^3; that is, with a power of 3 where there shouldn't have been one.